### PR TITLE
apt-get update before attempting to install postfix

### DIFF
--- a/docker/prod/setup/postinstall-onprem.sh
+++ b/docker/prod/setup/postinstall-onprem.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eox pipefail
 
+apt-get update -qq
 
 # postfix.postinst tries to generate a hostname based on /etc/resolv.conf, which
 # gets copied in to the docker environment from the host system. On systems
@@ -14,7 +15,6 @@ if [ -f /run/.containerenv -o -f /.dockerenv ]; then
 	mv /bin/x-hostname /bin/hostname
 fi
 
-apt-get update -qq
 # embed all-in-one additional software
 apt-get install -y  \
 	postgresql-$CURRENT_PGVERSION \


### PR DESCRIPTION
My previous PR #9878 added a docker build workaround for systems without dots in their fqdn as reported by /etc/resolv.conf.

More recent versions of openproject appear to have changed when `apt-get update` is run, and so the `apt-get install` I introduced previously to correct that bug no longer works.

This PR just moves an `apt-get update` above that `apt-get install` to once again fix that problem.

Thanks!